### PR TITLE
Updated to handle writing multiple files to folder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,6 +165,21 @@ module.exports = function (grunt) {
                 },
                 src: 'test/fixture/index-external.html',
                 dest: 'test/generated/index-external.html'
+            },
+            'test-multiple-files-folder': {
+                options: {
+                    base: 'test/fixture',
+                    minify: true,
+                    width: 1300,
+                    height: 900,
+                css: [
+                    'test/fixture/styles/main.css',
+                    'test/fixture/styles/bootstrap.css'
+                ],
+                },
+                files: [
+                    {expand: true, cwd: 'test/fixture/multiple', src: ['*.html'], dest: 'test/generated/multiple-files-folder'}
+                ]
             }
         }
     });

--- a/tasks/critical.js
+++ b/tasks/critical.js
@@ -55,14 +55,24 @@ module.exports = function (grunt) {
             async.eachSeries(srcFiles,function(src,cb){
                 var opts = extend({},options);
                 opts.src = path.resolve(src).replace(basereplace,'');
+
+                // check if the destination is a folder and not a file
+                var destination;
+                if (grunt.file.isDir(f.dest)) {
+
+                    destination = path.join(f.dest, src);
+                } else  {
+                    destination = f.dest;
+                }
+
                 try {
                     critical[command](opts, function (err, output){
                         if (err) {
                             return cb(err);
                         }
-                        grunt.file.write(f.dest, output);
+                        grunt.file.write(destination, output);
                         // Print a success message.
-                        grunt.log.ok('File "' + f.dest + '" created.');
+                        grunt.log.ok('File "' + destination + '" created.');
 
                         cb(null,output);
                     });
@@ -71,7 +81,7 @@ module.exports = function (grunt) {
                 }
             },function(e) {
                 if (e) {
-                    grunt.fail.warn('File "' + f.dest + '" failed.');
+                    grunt.fail.warn('File "' + destination + '" failed.');
                     grunt.log.warn(e.message || e);
 
                 }

--- a/tasks/critical.js
+++ b/tasks/critical.js
@@ -81,7 +81,7 @@ module.exports = function (grunt) {
                 }
             },function(e) {
                 if (e) {
-                    grunt.fail.warn('File "' + destination + '" failed.');
+                    grunt.fail.warn('File "' + f.dest + '" failed.');
                     grunt.log.warn(e.message || e);
 
                 }


### PR DESCRIPTION
As discovered in issue [#12](https://github.com/bezoerb/grunt-critical/issues/12), when trying
to write multiple files to a folder, the write fails because it assumes that the path is a file and not a folder.

I have updated the code to check first if the destination is a folder and update accordingly. See [this
issue](http://stackoverflow.com/a/20417119/335567) on SO for more information.