### PR TITLE
Use critical 0.5.7 to get ignore options.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "async": "^1.2.0",
-    "critical": "^0.5.6",
+    "critical": "^0.5.7",
     "fs-extra": "^0.18.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "async": "^1.2.0",
-    "critical": "^0.5.7",
+    "critical": "danielnitsche/critical",
     "fs-extra": "^0.18.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Critical 0.5.7 adds [ignore options](https://github.com/addyosmani/critical#generate-critical-path-css-and-ignore-specific-selectors), it would be great to be able to use those.