### PR TITLE
Update Travis CI from the latest grunt-contrib-internal.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,18 @@
+sudo: false
+
 language: node_js
+
 node_js:
-  - "stable"
+  - "0.10"
   - "0.12"
+  - "4"
+  - "5"
+  - "6"
+  - "iojs"
+
+matrix:
+  fast_finish: true
+
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
Note that I can't find anything relevant for node.js 0.10 in your git log, so for now I put it back.

You should have an engines property set up in package.json.