### PR TITLE
fix(fail): add grunt.fail in place of log, so the grunt process will exit

### DIFF
--- a/tasks/critical.js
+++ b/tasks/critical.js
@@ -60,12 +60,14 @@ module.exports = function (grunt) {
 
             // nothing to do
             if (srcFiles.length === 0) {
-                grunt.log.warn('Destination (' + f.dest + ') not written because src files were empty.');
+                var errorMsg = 'Destination (' + f.dest + ') not written because src files were empty.';
+                grunt.fail.warn(errorMsg, [1]);
                 return;
             }
 
             if (srcFiles.length > 1 && !grunt.file.isDir(f.dest)) {
-                grunt.log.warn('Destination needs to be a directory for multiple src files');
+                var errorMsg = 'Destination needs to be a directory for multiple src files';
+                grunt.fail.warn(errorMsg, [1]);
                 return;
             }
 


### PR DESCRIPTION
`grunt.log.warn` will not kill the grunt process, so the grunt process will hang if `src` files were empty.