### PR TITLE
Add support for generating uncritical CSS files #66

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 test/fixture/styles/bootstrap.*.css
 test/fixture/styles/main.*.css
 test/generated/
+.idea

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ critical: {
             height: 70
         },
         src: 'test/fixture/index.html',
-        dest: 'test/generated/critical.css'
+        dest: 'test/generated/critical.css',
+        target: {
+          uncritical: 'test/generated/uncritical.css'
+        }
     }
 }
 ```


### PR DESCRIPTION
I used the `target` option like in the current version of critical. The generation of the uncritical css is optional and the task works the same way before this pr when the option is omitted.